### PR TITLE
Parse errors before reading parsed values

### DIFF
--- a/lib/AWS/S3/ResponseParser.pm
+++ b/lib/AWS/S3/ResponseParser.pm
@@ -88,6 +88,7 @@ has 'friendly_error' => (
     default  => sub {
         my $s = shift;
 
+        $s->_parse_errors;
         return unless $s->error_code || $s->error_message;
         $s->type . " call had errors: [" . $s->error_code . "] " . $s->error_message;
     }


### PR DESCRIPTION
When we check whether an error occured by accessing the relevant
attributes, we need to parse the errors into these attributes before.
