### PR TITLE
Never send us-east-1 as a requested region for CreateBucket

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 
 Changelog for perl module AWS::S3
 
+  - More fixes for ->add_bucket. Fix an error when no location is provided or
+    us-east-1 is explicitly asked for. Patch by Dave Rolsky. (GH #9)
+
 0.14 2018-04-13
   - Fix sending of undefined location param in ->add_bucket (GH #9)
 

--- a/lib/AWS/S3/Request/CreateBucket.pm
+++ b/lib/AWS/S3/Request/CreateBucket.pm
@@ -16,11 +16,6 @@ has 'location' => (
     is       => 'ro',
     isa      => 'Maybe[Str]',
     required => 0,
-    lazy     => 1,
-
-    # https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUT.html
-    # "By default, the bucket is created in the US East (N. Virginia) region."
-    default  => sub { 'us-east-1' },
 );
 
 has '+_expect_nothing' => ( default => 1 );
@@ -28,11 +23,18 @@ has '+_expect_nothing' => ( default => 1 );
 sub request {
     my $s = shift;
 
-    my $xml = <<"XML";
+    # By default the bucket is put in us-east-1. But if you _ask_ for
+    # us-east-1 you get an error.
+    my $xml = q{};
+    if ( $s->location && $s->location ne 'us-east-1' ) {
+        $xml = <<"XML";
 <CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"> 
-  <LocationConstraint>@{[ $s->location || 'us-east-1' ]}</LocationConstraint> 
+  <LocationConstraint>@{[ $s->location ]}</LocationConstraint>
 </CreateBucketConfiguration>
 XML
+    }
+
+    print $xml;
 
     my $signer = AWS::S3::Signer->new(
         s3           => $s->s3,


### PR DESCRIPTION
If no bucket location is specified or if us-east-1 is asked for we must not
include an XML body at all. Explicitly asking for us-east-1 causes S3 to
return an error.

Fixes #9.