### PR TITLE
Fix using AWS::S3 for Linode E3 object store

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,6 +32,7 @@ WriteMakefile(
         'URI'             => 1.59,
         'URI::QueryParam' => 0,
         'Date::Parse'     => 0,
+        'Log::Any'        => '1.718',
       },
     BUILD_REQUIRES => {
         'Test::More'       => 0.31,

--- a/lib/AWS/S3.pm
+++ b/lib/AWS/S3.pm
@@ -8,6 +8,7 @@ use HTTP::Response;
 use HTTP::Request::Common;
 use IO::Socket::INET;
 use Class::Load 'load_class';
+use Log::Any qw( $LOG );
 
 use AWS::S3::ResponseParser;
 use AWS::S3::Owner;
@@ -69,6 +70,7 @@ sub request {
     my ( $s, $type, %args ) = @_;
 
     my $class = "AWS::S3::Request::$type";
+    $LOG->debug('Loading AWS request class', {class => $class});
     load_class( $class );
     return $class->new( %args, s3 => $s, type => $type );
 }    # end request()
@@ -104,6 +106,7 @@ sub buckets {
           );
     }    # end foreach()
 
+    $LOG->debug('Listed AWS buckets', { buckets => [map $_->name, @buckets] });
     return @buckets;
 }    # end buckets()
 
@@ -329,6 +332,12 @@ On success, returns the new L<AWS::S3::Bucket>
 On failure, dies with the error message.
 
 See L<AWS::S3::Bucket> for details on how to use buckets (and access their files).
+
+=head1 ENVIRONMENT VARIABLES
+
+=head2 AWS_S3_DEBUG
+
+If set, will print out debugging information to C<STDERR>.
 
 =head1 SEE ALSO
 

--- a/lib/AWS/S3.pm
+++ b/lib/AWS/S3.pm
@@ -70,7 +70,7 @@ sub request {
     my ( $s, $type, %args ) = @_;
 
     my $class = "AWS::S3::Request::$type";
-    $LOG->debug('Loading AWS request class', {class => $class});
+
     load_class( $class );
     return $class->new( %args, s3 => $s, type => $type );
 }    # end request()

--- a/lib/AWS/S3/Roles/Request.pm
+++ b/lib/AWS/S3/Roles/Request.pm
@@ -5,6 +5,7 @@ use AWS::S3::ResponseParser;
 use MooseX::Types::URI qw(Uri);
 use URI::Escape qw/ uri_escape /;
 use AWS::S3::Signer::V4;
+use Log::Any qw( $LOG );
 
 has 's3' => (
     is       => 'ro',
@@ -97,6 +98,7 @@ has 'signerv4' => (
 
 sub _send_request {
     my ( $s, $method, $uri, $headers, $content ) = @_;
+    $LOG->debug('Making AWS request', {method => $method, uri => "$uri"});
 
     my $req = HTTP::Request->new( $method => $uri );
     $req->content( $content ) if $content;


### PR DESCRIPTION
This PR fixes AWS::S3 to work with Linode's "S3-compatible" object storage using their "E3 endpoints".

Apparently, Linode has [4 different levels/generations/versions of endpoints](https://www.akamai.com/blog/developers/introducing-new-akamai-object-storage-endpoints). I started with using the "E1" endpoints, but when I asked for a quota increase (to store all 150,000,000 CPAN Testers reports), they told me I should be using their "E3" endpoints.

AWS::S3 worked fine with their E1 endpoints, but failed when using the E3 endpoints. I narrowed it down to the E3 endpoints not having an XML prolog or the expected `xmlns` attribute.

E1 endpoint (working):

```
Making AWS request {method => "GET",uri => "https://us-sea-1.linodeobjects.com/"}
>>> AWS Response:
<?xml version="1.0" encoding="UTF-8"?><ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>0d84dc50-3e86-407d-b5c2-5b9183eaea37</ID><DisplayName>0d84dc50-3e86-407d-b5c2-5b9183eaea37</DisplayName></Owner><Buckets><Bucket><Name>test-v1</Name><CreationDate>2026-01-08T17:43:29.701Z</CreationDate></Bucket></Buckets></ListAllMyBucketsResult>
Listed AWS buckets {buckets => ["test-v1"]}
```

E3 endpoint (not working):

```
Making AWS request {method => "GET",uri => "https://us-sea-9.linodeobjects.com/"}
>>> AWS Response:
<ListAllMyBucketsResult><Owner><ID>0d84dc50-3e86-407d-b5c2-5b9183eaea37</ID></Owner><Buckets><Bucket><Name>cpantesters-reports-v3</Name><CreationDate>2026-01-08T16:05:09+00:00</CreationDate></Bucket></Buckets></ListAllMyBucketsResult>
Listed AWS buckets {buckets => []}
```

One could make the argument that this is a Linode problem, and I was going to treat it as such until I learned that the XML prolog is apparently _optional_. I'd still argue this is a Linode problem, but this PR lets me get on with the work instead of waiting and hoping Linode fixes something that (probably, to them) isn't really "broken"...

This PR also includes some logging via Log::Any and some additional debugging that can be enabled by an environment variable. I may be biased, but I think the burden of Log::Any as a dependency is worth it, but I did not want full text of API responses in the logging so I had to also add the debugging flag. I'd be fine with or without these additions.